### PR TITLE
3: Whitelabeling and Regulations fulfilment

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
 from setuptools import setup
 
-__version="1.0.6"
+__version="1.0.7"
 
 spec = {
-    "name": "oc_pyfs",
+    "name": "oc-pyfs",
     "version": __version,
     "license": "Apache License 2.0",
     "description": "PyFilesystem interfaces",
@@ -13,10 +13,10 @@ spec = {
     "install_requires": [
         "chardet >= 2.3.0",
         "fs",
-        "oc_cdtapi"
+        "oc-cdtapi"
     ],
     "package_data": {},
-    "python_requires": ">=2.6",
+    "python_requires": ">=3.6",
 }
 
 setup(**spec)


### PR DESCRIPTION
- Module renamed (oc-pyfs) in order to fit Regulations
- dependencies updated
- Python version actualized (>=3.6 - we do not build for 2.7 any more because of *PySVN* binaries absence)